### PR TITLE
feat: lazily load images in includes

### DIFF
--- a/_includes/archive-single-cv.html
+++ b/_includes/archive-single-cv.html
@@ -23,7 +23,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="" loading="lazy">
       </div>
     {% endif %}
     <h3 class="archive__item-title" itemprop="headline">

--- a/_includes/archive-single-talk-cv.html
+++ b/_includes/archive-single-talk-cv.html
@@ -23,7 +23,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="" loading="lazy">
       </div>
     {% endif %}
     <h3 class="archive__item-title" itemprop="headline">

--- a/_includes/archive-single-talk.html
+++ b/_includes/archive-single-talk.html
@@ -22,7 +22,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="" loading="lazy">
       </div>
     {% endif %}
     <h2 class="archive__item-title" itemprop="headline">

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -22,7 +22,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="" loading="lazy">
       </div>
     {% endif %}
 

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -8,9 +8,9 @@
 
   <div class="author__avatar">
     {% if author.avatar contains "://" %}
-    	<img src="{{ author.avatar }}" alt="{{ author.name }}">
+        <img src="{{ author.avatar }}" alt="{{ author.name }}" loading="lazy">
     {% else %}
-    	<img src="{{ author.avatar | prepend: "/images/" | prepend: base_path }}" class="author__avatar" alt="{{ author.name }}">
+        <img src="{{ author.avatar | prepend: "/images/" | prepend: base_path }}" class="author__avatar" alt="{{ author.name }}" loading="lazy">
     {% endif %}
   </div>
 

--- a/_includes/comment.html
+++ b/_includes/comment.html
@@ -1,6 +1,6 @@
 <article id="comment{{ include.index }}" class="js-comment comment">
   <div class="comment__avatar-wrapper">
-    <img class="comment__avatar" src="https://www.gravatar.com/avatar/{{ include.email }}?d=mm&s=80">
+    <img class="comment__avatar" src="https://www.gravatar.com/avatar/{{ include.email }}?d=mm&s=80" loading="lazy">
   </div>
   <div class="comment__content-wrapper">
     <h3 class="comment__author">

--- a/_includes/feature_row
+++ b/_includes/feature_row
@@ -26,7 +26,7 @@
               {% else %}
                 "{{ f.image_path | prepend: "/images/" | prepend: base_path }}"
               {% endif %}
-            alt="{% if f.alt %}{{ f.alt }}{% endif %}">
+            alt="{% if f.alt %}{{ f.alt }}{% endif %}" loading="lazy">
           </div>
         {% endif %}
 

--- a/_includes/gallery
+++ b/_includes/gallery
@@ -31,7 +31,7 @@
           {% else %}
             "{{ img.image_path | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="{% if img.alt %}{{ img.alt }}{% endif %}">
+          alt="{% if img.alt %}{{ img.alt }}{% endif %}" loading="lazy">
       </a>
     {% else %}
       <img src=
@@ -40,7 +40,7 @@
         {% else %}
           "{{ img.image_path | prepend: "/images/" | prepend: base_path }}"
         {% endif %}
-        alt="{% if img.alt %}{{ img.alt }}{% endif %}">
+        alt="{% if img.alt %}{{ img.alt }}{% endif %}" loading="lazy">
     {% endif %}
   {% endfor %}
   {% if include.caption %}

--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -47,7 +47,7 @@
       {% endif %}
     </div>
   {% else %}
-    <img src="{{ img_path }}" alt="{{ page.title }}" class="page__hero-image">
+    <img src="{{ img_path }}" alt="{{ page.title }}" class="page__hero-image" loading="lazy">
   {% endif %}
   {% if page.header.caption %}
     <span class="page__hero-caption">{{ page.header.caption | markdownify | remove: "<p>" | remove: "</p>" }}</span>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -12,7 +12,7 @@
         {% else %}
           "{{ s.image | prepend: "/images/" | prepend: base_path }}"
         {% endif %}
-        alt="{% if s.image_alt %}{{ s.image_alt }}{% endif %}">
+        alt="{% if s.image_alt %}{{ s.image_alt }}{% endif %}" loading="lazy">
       {% endif %}
       {% if s.title %}<h3>{{ s.title }}</h3>{% endif %}
       {% if s.text %}{{ s.text | markdownify }}{% endif %}


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to hero and author profile images
- enable lazy loading on sidebar, gallery, feature rows, archive teasers, and comment avatars

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c17eca834883219ead45fb409f79ac