### PR TITLE
Add alt text to archive include teaser images

### DIFF
--- a/_includes/archive-single-cv.html
+++ b/_includes/archive-single-cv.html
@@ -23,7 +23,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="{{ title }}">
       </div>
     {% endif %}
     <h3 class="archive__item-title" itemprop="headline">

--- a/_includes/archive-single-talk-cv.html
+++ b/_includes/archive-single-talk-cv.html
@@ -23,7 +23,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="{{ title }}">
       </div>
     {% endif %}
     <h3 class="archive__item-title" itemprop="headline">

--- a/_includes/archive-single-talk.html
+++ b/_includes/archive-single-talk.html
@@ -22,7 +22,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="{{ title }}">
       </div>
     {% endif %}
     <h2 class="archive__item-title" itemprop="headline">

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -22,7 +22,7 @@
           {% else %}
             "{{ teaser | prepend: "/images/" | prepend: base_path }}"
           {% endif %}
-          alt="">
+          alt="{{ title }}">
       </div>
     {% endif %}
 


### PR DESCRIPTION
## Summary
- assign post titles as `alt` text for teaser images in archive include templates
- update archive templates for talks and CV entries to avoid empty `alt` attributes

## Testing
- `bundle exec jekyll build` *(fails: jekyll missing, bundle install required)*
- `bundle install` *(fails: HTTP 403 fetching gems)*
- `npm test` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68c17ed1cb988321988109b50d1050dc