### PR TITLE
Improve masthead accessibility

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -3,7 +3,7 @@
 <div class="masthead">
   <div class="masthead__inner-wrap">
     <div class="masthead__menu">
-      <nav id="site-nav" class="greedy-nav">
+      <nav id="site-nav" class="greedy-nav" aria-label="Primary">
         <button><div class="navicon"></div></button>
         <ul class="visible-links">
           <li class="masthead__menu-item masthead__menu-item--lg persist"><a href="{{ base_path }}/">{{ site.title }}</a></li>
@@ -16,7 +16,7 @@
             <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
           {% endfor %}
           <li id="theme-toggle" class="masthead__menu-item persist tail">
-            <a><i id="theme-icon" class="fa-solid fa-sun" aria-hidden="true" title="toggle theme"></i></a>
+            <button aria-label="Toggle theme"><i id="theme-icon" class="fa-solid fa-sun" aria-hidden="true" title="toggle theme"></i></button>
           </li>
         </ul>
         <ul class="hidden-links hidden"></ul>


### PR DESCRIPTION
## Summary
- label primary navigation for accessibility
- switch theme toggle from link to button with aria-label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c17edf056c8321af5c9ff65e686e5a