### PR TITLE
Update site title to Thomas Kaas

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@
 # Basic Site Settings
 locale                   : "en-US"
 site_theme               : "default"
-title                    : "Home"
+title                    : "Thomas Kaas"
 title_separator          : "-"
 name                     : &name "Thomas Kaas"
 description              : &description "Physician & Scientist"


### PR DESCRIPTION
## Summary
- rename site title to display "Thomas Kaas" instead of "Home" in browser tabs

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c17f47778c8321ac36f07897539fed