### PR TITLE
Remove sitemap link from footer

### DIFF
--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,3 +1,2 @@
 <!-- start custom footer snippets -->
-<a href="/sitemap/">Sitemap</a>
 <!-- end custom footer snippets -->


### PR DESCRIPTION
## Summary
- remove the sitemap link from the custom footer so it no longer appears at the bottom of pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec4aaf36883218d6a17c7d5652ca4